### PR TITLE
#101 - Added owner into Thesis information

### DIFF
--- a/grails-app/views/thesis/show.gsp
+++ b/grails-app/views/thesis/show.gsp
@@ -84,6 +84,13 @@
                 </dd>
                 </g:if>
                 <dt class="tms-tooltip" data-placement="left"
+                    data-original-title="${message(code: 'role.owner.label').toString()}">
+                    <i class="icon-user-md"></i>
+                </dt>
+                <dd>
+                    <g:link controller="user" action="show" id="${thesisInstance?.topic?.ownerId}"><g:fieldValue field="fullName" bean="${thesisInstance?.topic?.owner}"/></g:link>
+                </dd>
+                <dt class="tms-tooltip" data-placement="left"
                     data-original-title="${message(code: 'thesis.dateCreated.label').toString()}">
                     <i class="icon-time"></i>
                 </dt>


### PR DESCRIPTION
Used **user-md** icon to differentiate between owner and supervisor. Here is preview of how it looks.
![Thesis info panel](http://i.imgur.com/2XpU7g7.png)