### PR TITLE
#58 - Allow registration mail filter to operate over 2nd level domains

### DIFF
--- a/grails-app/controllers/com/redhat/theses/ConfigurationCommand.groovy
+++ b/grails-app/controllers/com/redhat/theses/ConfigurationCommand.groovy
@@ -1,0 +1,27 @@
+package com.redhat.theses
+
+import org.apache.commons.collections.ListUtils
+import org.apache.commons.collections.FactoryUtils
+import grails.validation.Validateable
+
+@Validateable
+class ConfigurationCommand {
+
+    List<String> domains = new ArrayList<String>()
+    List<String> defaultSupervisors = new ArrayList<String>()
+    List<String> defaultLeaders = new ArrayList<String>()
+    List<String> defaultAdmins = new ArrayList<String>()
+        
+    static constraints = {
+        domains validator: validateDomains
+        defaultSupervisors validator: validateDomains
+        defaultLeaders validator: validateDomains
+        defaultAdmins validator: validateDomains
+    }
+    
+    static validateDomains = {list, object->
+        if (list.any {(it =~ /[^a-zA-Z0-9-\\*\\.]+/).find()}) {
+            'invalid'
+        }
+    }  
+}

--- a/grails-app/controllers/com/redhat/theses/ConfigurationController.groovy
+++ b/grails-app/controllers/com/redhat/theses/ConfigurationController.groovy
@@ -30,6 +30,28 @@ class ConfigurationController {
         ConfigObject config = new ConfigObject()
         config.putAll(params.configuration ?: [:])
         configuration.setConfig(config)
+        
+        def configurationCommand = new ConfigurationCommand()
+        
+        params.configuration?.emailDomains.each {
+            configurationCommand.domains.push(it)
+        }
+        params.configuration?.defaultSupervisors.each {
+            configurationCommand.defaultSupervisors.push(it)
+        }
+        params.configuration?.defaultLeaders.each {
+            configurationCommand.defaultLeaders.push(it)
+        }
+        params.configuration?.defaultAdmins.each {
+            configurationCommand.defaultAdmins.push(it)
+        }
+        
+        configurationCommand.validate()
+        
+        if (configurationCommand.hasErrors()) {
+            render view: 'index', model: [configurationCommand: configurationCommand, config: config]
+            return
+        }
 
         if (!configuration.save()) {
             flash.message = message(code: 'config.not.updated')

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -120,6 +120,11 @@ registrationCommand.termsOfUse.disagree=To proceed you need to agree with terms 
 
 supervisionCommand.supervisions.supervisor.not.found=One of the given supervisors does not exist
 
+configurationCommand.domains.invalid=Your allowed email configuration contains forbidden characters
+configurationCommand.defaultSupervisors.invalid=Your email configuration for default Supervisors contains forbidden characters
+configurationCommand.defaultLeaders.invalid=Your email configuration for default Leaders contains forbidden characters
+configurationCommand.defaultAdmins.invalid=Your email configuration for default Admins contains forbidden characters
+
 faqCommand.faq.error.many=Some of the entered questions contain errors.
 
 faq.question.blank=Question cannot be blank.

--- a/grails-app/i18n/messages_cs.properties
+++ b/grails-app/i18n/messages_cs.properties
@@ -119,6 +119,11 @@ registrationCommand.termsOfUse.disagree=Pro dokončení registrace musíte souhl
 
 supervisionCommand.supervisions.supervisor.not.found=Jeden ze zadaných vedoucích neexistuje
 
+configurationCommand.domains.invalid=Vaše nastavení povolených emailových domén obsahuje nepovolené znaky
+configurationCommand.defaultSupervisors.invalid=Vaše nastavení emailových domén pro defaultní Univerzitní vedoucí obsahuje nepovolené znaky
+configurationCommand.defaultLeaders.invalid=Vaše nastavení emailových domén pro defaultní Vedoucí obsahuje nepovolené znaky
+configurationCommand.defaultAdmins.invalid=Vaše nastavení emailových domén pro defaultní Administrátory obsahuje nepovolené znaky
+
 faqCommand.faq.error.many=Některé ze zadaných otázek obsahují chyby
 
 faq.question.blank=Otázka nemůže být prázdná

--- a/grails-app/views/configuration/_form.gsp
+++ b/grails-app/views/configuration/_form.gsp
@@ -40,7 +40,7 @@
 
 <fieldset>
     <legend><g:message code="config.email.domains.header" /></legend>
-    <div class="control-group">
+    <div class="control-group ${hasErrors(bean: configurationCommand, field: 'domains', 'error')}">
         <label class="control-label" for="email-domain-list">
             <strong><g:message code="config.email.domains.label" /></strong>
         </label>
@@ -60,7 +60,7 @@
 
 <fieldset>
     <legend><g:message code="config.default.supervisors.header" /></legend>
-    <div class="control-group">
+    <div class="control-group ${hasErrors(bean: configurationCommand, field: 'defaultSupervisors', 'error')}">
         <label class="control-label" for="default-supervisors-list">
             <strong><g:message code="config.default.supervisors.label" /></strong>
         </label>
@@ -80,7 +80,7 @@
 
 <fieldset>
     <legend><g:message code="config.default.leaders.header" /></legend>
-    <div class="control-group">
+    <div class="control-group ${hasErrors(bean: configurationCommand, field: 'defaultLeaders', 'error')}">
         <label class="control-label" for="default-leaders-list">
             <strong><g:message code="config.default.leaders.label" /></strong>
         </label>
@@ -100,7 +100,7 @@
 
 <fieldset>
     <legend><g:message code="config.default.admins.header" /></legend>
-    <div class="control-group">
+    <div class="control-group ${hasErrors(bean: configurationCommand, field: 'defaultAdmins', 'error')}">
         <label class="control-label" for="default-admins-list">
             <strong><g:message code="config.default.admins.label" /></strong>
         </label>

--- a/src/groovy/com/redhat/theses/util/Util.groovy
+++ b/src/groovy/com/redhat/theses/util/Util.groovy
@@ -119,7 +119,8 @@ class Util {
      * @return true if email address is hosted at the given domain, false otherwise
      */
     static Boolean hasDomain(String email, String domain) {
-        email =~ /@${domain.replaceAll('.', '\\.')}$/
+        //Change all *, which are not followed by ., for *. and replace all uncommented . for commented ones 
+        email =~ /@${domain.replaceAll('\\*(?!\\.)','\\*\\.').replace('.', '\\.')}$/
     }
 
     /**

--- a/test/unit/com/redhat/theses/util/UtilSpecification.groovy
+++ b/test/unit/com/redhat/theses/util/UtilSpecification.groovy
@@ -1,0 +1,29 @@
+package com.redhat.theses.util
+
+import com.redhat.theses.util.Util
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class UtilSpecification extends Specification {
+    
+    def setupSpec() {
+    }
+
+    def cleanup() {        
+    }
+    
+    @Unroll("Will allow email #email through filter #domain, expected #result")
+    void "test email filter"() {
+        expect:
+            Util.hasDomain(email, domain) == result
+        where:
+            email | domain | result
+            "test@test.redhat.com" | "*.redhat.com" | true
+            "test@fit.vutbr.cz" | "*vutbr.cz" | true
+            "@fit.vutbr.cz" | "*vutbr.cz" | true
+            "test@testuredhat.com"| "*.redhat.com" | false
+            "test@fitvutbr.cz" | "*vutbr.cz" | false
+            "test@xyz" | "vutbr.cz" | false
+            "test@fit.vutbr.cz" | "vutbr.cz" | false
+    }
+}


### PR DESCRIPTION
# Overview
Only thing I had to do was change function **replaceAll()** for **replace()**, and only difference between these functions that **replaceAll()** accepts REGEX patterns, which is not needed when replacing dots. Email filter should now accept all REGEX patterns except for dot, which is being filtered out. I also created test to prove that method now accepts patterns.

# Changes in files
**Util.groovy**
* Changed **replaceAll()** for **replace()** in **hasDomain()** function.

**test/unit/UtilSpecification.groovy**
* Unit Test for testing pattern acceptance in **hasDomain()** function.