### PR TITLE
#122 - Changed 'supervisor' to 'Academic Supervisor' and 'leader' to 'Technical Leader'

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -76,16 +76,16 @@ comment.content.blank=Content of the comment cannot be blank
 topic.title.blank=Title cannot be blank
 topic.description.blank=Description cannot be blank
 topic.lead.blank=Lead paragraph cannot be blank
-topic.owner.nullable=You must specify the leader
-topic.owner.not.found=Given user [{2}] does not exist or the user is not a leader.
+topic.owner.nullable=You must specify the Technical Supervisor
+topic.owner.not.found=Given user [{2}] does not exist or the user is not a Technical Supervisor.
 
 thesis.title.blank=Title cannot be blank
-thesis.supervisor.not.found=Given user [{2}] does not exist or the user is not a supervisor.
+thesis.supervisor.not.found=Given user [{2}] does not exist or the user is not a Academic Supervisor.
 thesis.assignee.not.found=Given user [{2}] does not exist
 thesis.topic.not.found=Given topic [{2}] does not exist
 thesis.description.blank=Description cannot be blank
 thesis.assignee.nullable=You must specify the assignee
-thesis.supervisor.nullable=You must specify the supervisor
+thesis.supervisor.nullable=You must specify the Academic Supervisor
 thesis.university.nullable=You must specify the university
 thesis.type.nullable=You must specify the type
 
@@ -115,10 +115,10 @@ registrationCommand.password.minSize.notmet=Password must be at least 6 characte
 registrationCommand.email.blank=Email cannot be blank
 registrationCommand.email.email=Invalid email
 registrationCommand.fullName.blank=Full name cannot be blank
-registrationCommand.email.not.unique=User with given email is already signed up. If you have already tried to register with this email address and did not receive a confirmation email, try it again in 24 hours or contact the administrator
+registrationCommand.email.not.unique=User with given email is already signed up. If you have already tried to register with this email address and did not receive a confirmation email, try it again in 24 hours or contact the Administrator
 registrationCommand.termsOfUse.disagree=To proceed you need to agree with terms of use
 
-supervisionCommand.supervisions.supervisor.not.found=One of the given supervisors does not exist
+supervisionCommand.supervisions.supervisor.not.found=One of the given Academic Supervisors does not exist
 
 faqCommand.faq.error.many=Some of the entered questions contain errors.
 
@@ -219,8 +219,8 @@ user.optimistic.lock.error=Another user has updated this user while you were edi
 
 # ROLES
 role.admin.label=Admin
-role.owner.label=Leader
-role.supervisor.label=Supervisor
+role.owner.label=Technical Supervisor
+role.supervisor.label=Academic Supervisor
 role.student.label=Student
 
 # APPLICATION
@@ -287,7 +287,7 @@ topic.enabled.label=Enabled
 topic.universities.label=Universities
 topic.types.label=Types
 topic.supervision.label=Supervision
-topic.supervisors.for=Supervisors for {0}
+topic.supervisors.for=Academic Supervisors for {0}
 topic.lead.label=Lead Paragraph
 topic.description.label=Description in English
 topic.secondaryDescription.label=Description in Czech
@@ -528,12 +528,12 @@ supervision.updated=Your supervision has been successfully updated
 # CONFIGURATION
 config.email.domains.header=Allowed email domains
 config.email.domains.label=Domains
-config.default.supervisors.label=Users with following email domains will have role supervisor by default
-config.default.supervisors.header=Default supervisors
-config.default.leaders.label=Users with following email domains will have role leader by default
-config.default.leaders.header=Default leaders
-config.default.admins.label=Users with following email domains will have role administrator by default
-config.default.admins.header=Default administrators
+config.default.supervisors.label=Users with following email domains will have role Academic Supervisor by default
+config.default.supervisors.header=Default Academic Supervisors
+config.default.leaders.label=Users with following email domains will have role Technical Supervisor by default
+config.default.leaders.header=Default Technical Supervisors
+config.default.admins.label=Users with following email domains will have role Administrator by default
+config.default.admins.header=Default Administrators
 config.termsOfUse.header=Terms of Use
 config.termsOfUse.label= Text
 config.announcement.header=Site announcement
@@ -745,7 +745,7 @@ info.thesis.create.topic=The topic of the thesis.
 info.thesis.create.title=Title of the thesis.
 info.thesis.create.asignee=The student assigned for the thesis.
 info.thesis.create.university=The university of the assigned student.
-info.thesis.create.supervisor=The supervisor from the university.
+info.thesis.create.supervisor=The Academic Supervisor from the university.
 info.thesis.create.type=Whether the thesis is offered to undergraduate or graduate student.
 info.thesis.create.status=Current status of the thesis.
 info.thesis.create.grade=The grade awarded to the student after they finished the thesis.
@@ -756,7 +756,7 @@ info.thesis.create.links=List of external links.
 
 info.application.create.university=University where you study.
 info.application.create.type=Your type of study.
-info.application.create.note=Note or message for the leader of the topic (maximum 255 characters).
+info.application.create.note=Note or message for the Technical Supervisor of the topic (maximum 255 characters).
 
 info.category.create.title=The name of the category.
 info.category.create.description=Brief description of the category.
@@ -766,9 +766,9 @@ info.university.create.acronym=Short name of the university (acronym).
 
 info.user.create.email=User's email address.
 info.user.create.fullName=Full name of the user.
-info.user.create.roles=List of roles of the user. Each role represents certain permissions. For example, admin can create new users, leader can create new topics etc.
+info.user.create.roles=List of roles of the user. Each role represents certain permissions. For example, Admin can create new users, Technical Supervisor can create new topics etc.
 
 info.filter.user=Filter members by user's full name or email. You may also put in only a part of an email/full name. By default, only enabled users are views, you can view also disabled users by unchecking option 'Show only enabled users'.
-info.filter.topic=Filter topics by title (the primary title, i.e. the title in english), leader's full name, supervisor's full name or university name. You may put in only a part of the full name or title. By default, this page shows only enabled topics, you can show also disabled topic by unchecking option 'Show only enabled topics'.
-info.filter.thesis=Filter thesis by one of the following fields. You may also put in only a part of the title/supervisor's full name/asignee's full name.
+info.filter.topic=Filter topics by title (the primary title, i.e. the title in english), Technical Supervisor's full name, Academic Supervisor's full name or university name. You may put in only a part of the full name or title. By default, this page shows only enabled topics, you can show also disabled topic by unchecking option 'Show only enabled topics'.
+info.filter.thesis=Filter thesis by one of the following fields. You may also put in only a part of the title/Academic Supervisor's full name/asignee's full name.
 info.filter.application=Filter applications by applicant's full name, topic title (primary title, i.e. title in english) or status. You may also put in only a part of applicant's full name or topic's title.

--- a/grails-app/i18n/messages_cs.properties
+++ b/grails-app/i18n/messages_cs.properties
@@ -76,16 +76,16 @@ comment.content.blank=Obsah komentáře nemůže být prázdný
 topic.title.blank=Nadpis nemůže být prázdný
 topic.description.blank=Popis nemůže být prázdný
 topic.lead.blank=Perex nemůže být prázdný
-topic.owner.nullable=Musíte zadat vedoucího
-topic.owner.not.found=Zadaný uživatel [{2}] neexistuje nebo není vedoucí
+topic.owner.nullable=Musíte zadat Technického vedoucího
+topic.owner.not.found=Zadaný uživatel [{2}] neexistuje nebo není Technický vedoucí
 
 thesis.title.blank=Nadpis nemůže být prázdný
-thesis.supervisor.not.found=Zadaný uživatel [{2}] neexistuje neno není univerzitním vedoucím.
+thesis.supervisor.not.found=Zadaný uživatel [{2}] neexistuje neno není Univerzitním vedoucím.
 thesis.assignee.not.found=Zadaný student [{2}] neexistuje
 thesis.topic.not.found=Zadané téma [{2}] neexistuje
 thesis.description.blank=Popis nemůže být prázdný
 thesis.assignee.nullable=Musíte zadat studenta
-thesis.supervisor.nullable=Musíte zadat vedoucího na univerzitě
+thesis.supervisor.nullable=Musíte zadat Univerzitního vedoucího
 thesis.university.nullable=Musíte zadat univerzitu
 thesis.type.nullable=Musíte zadat typ
 
@@ -117,7 +117,7 @@ registrationCommand.fullName.blank=Jméno nemůže být prázdné
 registrationCommand.email.not.unique=Uživatel se zadaným emailem už je zaregistrovaný. Pokud jste se zkoušel zaregistrovat s tímto emailem a nedošel vám potvrzovací email, zkuste to znova za 24 hodin nebo kontaktujte administrátora
 registrationCommand.termsOfUse.disagree=Pro dokončení registrace musíte souhlasit s podmínkami používání
 
-supervisionCommand.supervisions.supervisor.not.found=Jeden ze zadaných vedoucích neexistuje
+supervisionCommand.supervisions.supervisor.not.found=Jeden ze zadaných Univerzitních vedoucích neexistuje
 
 faqCommand.faq.error.many=Některé ze zadaných otázek obsahují chyby
 
@@ -188,7 +188,7 @@ user.main.button=Hlavní
 
 user.led.topics=Seznam témat, které vlastníte
 user.supervised.theses=Seznam kvalifikačních prací, které vedete
-user.supervised.topics=Seznam témat, kde jste přiřazen jako vedoucí
+user.supervised.topics=Seznam témat, kde jste přiřazen jako Univerzitní vedoucí
 user.assigned.theses=Seznam vašich kvalifikačních prací
 
 user.applications.title=Přihláška pro uživatele: {0}
@@ -218,8 +218,8 @@ user.optimistic.lock.error=Jiný uživatel editoval tohoto uživatele zatím co 
 
 # ROLES
 role.admin.label=Admin
-role.owner.label=Vedoucí
-role.supervisor.label=Vedoucí na univerzitě
+role.owner.label=Technický Vedoucí
+role.supervisor.label=Univerzitní Vedoucí
 role.student.label=Student
 
 # APPLICATION
@@ -285,8 +285,8 @@ topic.secondaryTitle.label=Název česky
 topic.enabled.label=Povolen
 topic.universities.label=Univerzity
 topic.types.label=Typy
-topic.supervision.label=Vedoucí na univerzitě
-topic.supervisors.for=Vedoucí pro univerzitu {0}
+topic.supervision.label=Univerzitní vedoucí
+topic.supervisors.for=Univerzitní vedoucí pro {0}
 topic.lead.label=Perex
 topic.description.label=Popis anglicky
 topic.secondaryDescription.label=Popis česky
@@ -311,7 +311,7 @@ topic.list.header=Seznam témat
 topic.list.title=Seznam témat
 topic.printable-list.title=Vytisknutelný seznam témat
 topic.show.title=Téma: {0}
-dynamicField.add.supervision.button=Přidat vedoucího
+dynamicField.add.supervision.button=Přidat Univerzitního vedoucího
 topic.show.printable.button=Zobrazit vytisknutelnou verzi
 
 topic.show.only.enabled.label=Zobrazit pouze povolená témata
@@ -526,12 +526,12 @@ supervision.updated=Úspěšně uloženo
 # CONFIGURATION
 config.email.domains.header=Povolené emailové domény
 config.email.domains.label=Domény
-config.default.supervisors.label=Uživatelé s následujícími emailovými doménami budou mít defaultně roli univerzitní vedoucí
-config.default.supervisors.header=Defaultní univerzitní vedoucí
-config.default.leaders.label=Uživatelé s následujícími emailovými doménami budou mít defaultně roli vedoucí
-config.default.leaders.header=Defaultní vedoucí
-config.default.admins.label=Uživatelé s následujícími emailovými doménami budou mít defaultně roli administrátor
-config.default.admins.header=Defaultní administrátoři
+config.default.supervisors.label=Uživatelé s následujícími emailovými doménami budou mít defaultně roli Univerzitní vedoucí
+config.default.supervisors.header=Defaultní Univerzitní vedoucí
+config.default.leaders.label=Uživatelé s následujícími emailovými doménami budou mít defaultně roli Technický vedoucí
+config.default.leaders.header=Defaultní Techničtí vedoucí
+config.default.admins.label=Uživatelé s následujícími emailovými doménami budou mít defaultně roli Administrátor
+config.default.admins.header=Defaultní Administrátoři
 config.termsOfUse.header=Podmínky používání
 config.termsOfUse.label= Text
 config.announcement.header=Oznámení na hlavní stránce
@@ -732,7 +732,7 @@ info.topic.create.secondaryTitle=Sekundární název tématu česky.
 info.topic.create.owner=Osoba spravující toto téma.
 info.topic.create.universities=Seznam univerzit na kterých mohou být práce na toto téma vypsány.
 info.topic.create.types=Zda-li je téma určeno pro studenty bakalářského studia nebo magisterského.
-info.topic.create.supervision=Seznam vedoucích na zvolených univerzitách.
+info.topic.create.supervision=Seznam Univerzitních vedoucích na zvolených univerzitách.
 info.topic.create.lead=Stručný popis, který se zobrazí v seznamu témat.
 info.topic.create.description=Podrobný popis tématu anglicky.
 info.topic.create.secondaryDescription=Podrobný popis tématu česky.
@@ -743,7 +743,7 @@ info.thesis.create.topic=Téma kvalifikační práce.
 info.thesis.create.title=Název kvalifikační práce.
 info.thesis.create.asignee=Student přihlášen k této práci.
 info.thesis.create.university=Univerzita přihlášeného studenta.
-info.thesis.create.supervisor=Vedoucí kvalifikační práce na univerzitě.
+info.thesis.create.supervisor=Univerzitní vedoucí kvalifikační práce na univerzitě.
 info.thesis.create.type=Zda-li je téma určeno pro studenta bakalářského studia nebo magisterského.
 info.thesis.create.status=Aktuální stav kvalifikační práce.
 info.thesis.create.grade=Hodnocení uděleno studentovi po dokončení práce.
@@ -754,7 +754,7 @@ info.thesis.create.links=Seznam odkazů.
 
 info.application.create.university=Univerzita, na které studujete.
 info.application.create.type=Typ kvalifikační práce.
-info.application.create.note=Poznámka nebo krátká zpráva pro vedoucího tématu (maximálně 255 znaků).
+info.application.create.note=Poznámka nebo krátká zpráva pro Technického vedoucího tématu (maximálně 255 znaků).
 
 info.category.create.title=Název kategorie.
 info.category.create.description=Krátký popis kategorie.
@@ -764,9 +764,9 @@ info.university.create.acronym=Zkratka univerzity (např. MUNI).
 
 info.user.create.email=E-mailová adresa uživatele.
 info.user.create.fullName=Celeé jméno uživatele.
-info.user.create.roles=Seznam rolí uživatele. Každá role představuje určité oprávnění. Například administrátor může vytvářet nové uživatele, vedoucí nová témata atd.
+info.user.create.roles=Seznam rolí uživatele. Každá role představuje určité oprávnění. Například administrátor může vytvářet nové uživatele, Technický vedoucí nová témata atd.
 
 info.filter.user=Uživatele lze filtrovat podle jejich jména nebo e-mailové adresy. Zadat můžete také pouze část jména nebo e-mailu uživatele. Standardně se zobrazují pouze povolení uživatelé, můžete však zobrazit i zakázané uživatele odškrtnutím možnosti &bdquo;Zobrazit pouze povolené uživatele&rdquo;.
-info.filter.topic=Témata můžete filtrovat podle primárního názvu (tj. anglického názvu), jména vedoucího, podle vedoucího z univerzity nebo jména univerzity. Můžete také zadat pouze část jména nebo názvu. Tato stránka zobrazuje standardně pouze povolená témata, pokud potřebujete zobrazit i zakázaná témata, odškrtněte možnost &bdquo;Zobrazit pouze povolená témata&rdquo;.
+info.filter.topic=Témata můžete filtrovat podle primárního názvu (tj. anglického názvu), jména Technického vedoucího, podle Univerzitního vedoucího nebo jména univerzity. Můžete také zadat pouze část jména nebo názvu. Tato stránka zobrazuje standardně pouze povolená témata, pokud potřebujete zobrazit i zakázaná témata, odškrtněte možnost &bdquo;Zobrazit pouze povolená témata&rdquo;.
 info.filter.thesis=Kvalifikační práce můžete filtrovat jedním z následujících polí. Při filtrování lze také zadat pouze část názvu nebo jména.
 info.filter.application=Přihlášky můžete filtrovat podle primárního názvu témata (tj. anglického názvu), podle jména uživatele, který přihlášku podal, nebo podle stavu přihlášky. Lze také zadat pouze část jména nebo názvu. Standardně se zobrazují pouze přihlášky, které ještě nejsou schválené.


### PR DESCRIPTION
I changed only English localization, because Czech already has 'Vedoucí' a 'Vedoucí na Univerzitě', which should be descriptive enough.