### PR TITLE
#121 - Updated topic filter to search in title/description or lead paragraph

### DIFF
--- a/grails-app/controllers/com/redhat/theses/ThesisController.groovy
+++ b/grails-app/controllers/com/redhat/theses/ThesisController.groovy
@@ -48,12 +48,16 @@ class ThesisController {
         if (!params.filter) {
             params.filter = [:]    
         }
-        
+
         def tag = null
         if (params.filter?.tags?.title) {
             tag = Tag.get(new Tag(title: params.filter?.tags?.title))
         }
-        
+
+        if (params.filtering) {
+            params.type = [title: "ilike", supervisor: [fullName: "ilike"], assignee: [fullName: "ilike"]]
+        }
+
         params.filter?.status = Status.FINISHED
         
         def tagListWithUsage = tagService.findAllWithCountUsage(Thesis, [max: TAG_MAX])

--- a/grails-app/controllers/com/redhat/theses/TopicController.groovy
+++ b/grails-app/controllers/com/redhat/theses/TopicController.groovy
@@ -56,6 +56,10 @@ class TopicController {
             category = Category.get(params.filter?.categories?.long('id'))
         }
 
+        if (params.filtering) {
+            params.type = ["title-description-lead": "ilike", owner: [fullName: "ilike"], supervisions: [supervisor: [fullName: "ilike"]]]    
+        }
+        
         def tag = null
         if (params.filter?.tags?.title) {
             tag = Tag.get(new Tag(title: params.filter?.tags?.title))

--- a/grails-app/controllers/com/redhat/theses/auth/UserController.groovy
+++ b/grails-app/controllers/com/redhat/theses/auth/UserController.groovy
@@ -44,6 +44,10 @@ class UserController {
             ]
         }
 
+        if (params.filtering) {
+            params.type = [fullName: "ilike", email: "ilike"]
+        }
+
         def userInstanceList = filterService.filter(params, User)
         def userInstanceTotal = filterService.count(params, User)
 

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -281,6 +281,7 @@ comment.not.found=Comment with id {0} does not exist
 
 # TOPIC
 topic.label=Topic
+topic.filter.title=Title/Description/Lead paragraph in English
 topic.title.label= Title in English
 topic.secondaryTitle.label=Title in Czech
 topic.enabled.label=Enabled
@@ -769,6 +770,6 @@ info.user.create.fullName=Full name of the user.
 info.user.create.roles=List of roles of the user. Each role represents certain permissions. For example, admin can create new users, leader can create new topics etc.
 
 info.filter.user=Filter members by user's full name or email. You may also put in only a part of an email/full name. By default, only enabled users are views, you can view also disabled users by unchecking option 'Show only enabled users'.
-info.filter.topic=Filter topics by title (the primary title, i.e. the title in english), leader's full name, supervisor's full name or university name. You may put in only a part of the full name or title. By default, this page shows only enabled topics, you can show also disabled topic by unchecking option 'Show only enabled topics'.
+info.filter.topic=Filter topics by title/description/lead paragraph in English ,leader's full name, supervisor's full name or university name. You may put in only a part of the full name or title. By default, this page shows only enabled topics, you can show also disabled topic by unchecking option 'Show only enabled topics'.
 info.filter.thesis=Filter thesis by one of the following fields. You may also put in only a part of the title/supervisor's full name/asignee's full name.
 info.filter.application=Filter applications by applicant's full name, topic title (primary title, i.e. title in english) or status. You may also put in only a part of applicant's full name or topic's title.

--- a/grails-app/i18n/messages_cs.properties
+++ b/grails-app/i18n/messages_cs.properties
@@ -280,6 +280,7 @@ comment.not.found=Komentář s id {0} neexistuje
 
 # TOPIC
 topic.label=Téma
+topic.filter.title=Název/Popis/Perex anglicky
 topic.title.label=Název anglicky
 topic.secondaryTitle.label=Název česky
 topic.enabled.label=Povolen
@@ -767,6 +768,6 @@ info.user.create.fullName=Celeé jméno uživatele.
 info.user.create.roles=Seznam rolí uživatele. Každá role představuje určité oprávnění. Například administrátor může vytvářet nové uživatele, vedoucí nová témata atd.
 
 info.filter.user=Uživatele lze filtrovat podle jejich jména nebo e-mailové adresy. Zadat můžete také pouze část jména nebo e-mailu uživatele. Standardně se zobrazují pouze povolení uživatelé, můžete však zobrazit i zakázané uživatele odškrtnutím možnosti &bdquo;Zobrazit pouze povolené uživatele&rdquo;.
-info.filter.topic=Témata můžete filtrovat podle primárního názvu (tj. anglického názvu), jména vedoucího, podle vedoucího z univerzity nebo jména univerzity. Můžete také zadat pouze část jména nebo názvu. Tato stránka zobrazuje standardně pouze povolená témata, pokud potřebujete zobrazit i zakázaná témata, odškrtněte možnost &bdquo;Zobrazit pouze povolená témata&rdquo;.
+info.filter.topic=Témata můžete filtrovat podle primárního názvu/popisu/perexu, jména vedoucího, podle vedoucího z univerzity nebo jména univerzity. Můžete také zadat pouze část jména nebo názvu. Tato stránka zobrazuje standardně pouze povolená témata, pokud potřebujete zobrazit i zakázaná témata, odškrtněte možnost &bdquo;Zobrazit pouze povolená témata&rdquo;.
 info.filter.thesis=Kvalifikační práce můžete filtrovat jedním z následujících polí. Při filtrování lze také zadat pouze část názvu nebo jména.
 info.filter.application=Přihlášky můžete filtrovat podle primárního názvu témata (tj. anglického názvu), podle jména uživatele, který přihlášku podal, nebo podle stavu přihlášky. Lze také zadat pouze část jména nebo názvu. Standardně se zobrazují pouze přihlášky, které ještě nejsou schválené.

--- a/grails-app/services/com/redhat/theses/FilterService.groovy
+++ b/grails-app/services/com/redhat/theses/FilterService.groovy
@@ -109,15 +109,26 @@ class FilterService {
 
                         }
                     }
+                } else if(propName.contains("-")) {
+                    def properties = propName.split("-")
+                    c.or {
+                        for (String propertyName : properties) {
+                            addFilterParameter(c, domainClass, propertyName, rawValue, rawType)
+                        }
+                    }    
                 } else {
-                    def thisDomainProp = resolveDomainProperty(domainClass, propName)
-
-                    if (thisDomainProp) {
-                        def val = this.parseValue(thisDomainProp, rawValue)
-                        this.addCriterion(c, propName, val, rawType)
-                    }
+                    addFilterParameter(c, domainClass, propName, rawValue, rawType)
                 }
             }
+        }
+    }
+
+    private addFilterParameter(criteria, domainClass, propName, rawValue, rawType) {
+        def thisDomainProp = resolveDomainProperty(domainClass, propName)
+
+        if (thisDomainProp) {
+            def val = this.parseValue(thisDomainProp, rawValue)
+            this.addCriterion(criteria, propName, val, rawType)
         }
     }
 

--- a/grails-app/views/thesis/list.gsp
+++ b/grails-app/views/thesis/list.gsp
@@ -60,13 +60,10 @@
                     <g:hiddenField name="filter.tags.title" value="${params?.filter?.tags?.title}"/>
                     <g:textField value="${params?.filter?.title}" class="wide"
                                  name="filter.title" placeholder="${message(code: 'thesis.title.label')}"/>
-                    <g:hiddenField name="type.title" value="ilike"/>
                     <g:textField value="${params?.filter?.supervisor?.fullName}" class="wide"
                                  name="filter.supervisor.fullName" placeholder="${message(code: 'role.supervisor.label')}"/>
-                    <g:hiddenField name="type.supervisor.fullName" value="ilike"/>
                     <g:textField value="${params?.filter?.assignee?.fullName}" class="wide"
                                  name="filter.assignee.fullName" placeholder="${message(code: 'thesis.assignee.label')}"/>
-                    <g:hiddenField name="type.assignee.fullName" value="ilike"/>
                     <g:select name="filter.grade" from="${Grade.values()}"
                               noSelection="['':message(code:'thesis.grade.select.label')]"
                               value="${params?.filter?.grade}"

--- a/grails-app/views/topic/_topicList.gsp
+++ b/grails-app/views/topic/_topicList.gsp
@@ -78,16 +78,6 @@
                 </div>
             </div>
         </sec:ifAnyGranted>
-        <g:if test="${currentCategory}">
-            <h4><g:message code="category.label"/>: ${currentCategory?.title}</h4>
-        </g:if>
-        <g:else>
-            <h4><g:message code="topic.categories.label"/></h4>
-        </g:else>
-        <div class="panel-content">
-            <g:render template="categoryList" />
-        </div>
-
         <h4>
             <div class="small-msg pull-right">
                 <i class="icon-info-sign icon-large"
@@ -100,15 +90,12 @@
                 <g:hiddenField name="filtering" value="true"/>
                 <g:hiddenField name="filter.categories.id" value="${params?.filter?.categories?.id}"/>
                 <g:hiddenField name="filter.tags.title" value="${params?.filter?.tags?.title}"/>
-                <g:textField value="${params?.filter?.title}" class="wide"
-                             name="filter.title" placeholder="${message(code: 'topic.title.label')}"/>
-                <g:hiddenField name="type.title" value="ilike"/>
+                <g:textField value="${params?.filter?.'title-description-lead'}" class="wide"
+                             name="filter.title-description-lead" placeholder="${message(code: 'topic.filter.title')}"/>
                 <g:textField value="${params?.filter?.owner?.fullName}" class="wide"
                              name="filter.owner.fullName" placeholder="${message(code: 'role.owner.label')}"/>
-                <g:hiddenField name="type.owner.fullName" value="ilike"/>
                 <g:textField value="${params?.filter?.supervisions?.supervisor?.fullName}" class="wide"
                              name="filter.supervisions.supervisor.fullName" placeholder="${message(code: 'role.supervisor.label')}"/>
-                <g:hiddenField name="type.supervisions.supervisor.fullName" value="ilike"/>
                 <g:select name="filter.universities.id" from="${universities}"
                           noSelection="['':message(code:'topic.university.select.label')]"
                           optionKey="id" value="${params?.filter?.universities?.id}"
@@ -119,6 +106,15 @@
                     <g:checkBox name="filter.onlyEnabled" value="${params?.filter?.onlyEnabled}"/> <g:message code="topic.show.only.enabled.label"/>
                 </label>
             </g:form>
+        </div>        
+        <g:if test="${currentCategory}">
+            <h4><g:message code="category.label"/>: ${currentCategory?.title}</h4>
+        </g:if>
+        <g:else>
+            <h4><g:message code="topic.categories.label"/></h4>
+        </g:else>
+        <div class="panel-content">
+            <g:render template="categoryList" />
         </div>
 
         <h4><g:message code="topic.tags.label"/></h4>

--- a/grails-app/views/user/list.gsp
+++ b/grails-app/views/user/list.gsp
@@ -72,10 +72,8 @@
                     <g:hiddenField name="filtering" value="true"/>
                     <g:textField value="${params?.filter?.fullName}" class="wide"
                                  name="filter.fullName" placeholder="${message(code: 'user.fullName.label')}"/>
-                    <g:hiddenField name="type.fullName" value="ilike"/>
                     <g:textField value="${params?.filter?.email}" class="wide"
                                  name="filter.email" placeholder="${message(code: 'user.email.label')}"/>
-                    <g:hiddenField name="type.email" value="ilike"/>
                     <g:submitButton class="tms-btn pull-right" name="filter-button"
                                     value="${message(code: 'filter.button')}"/>
                     <label>

--- a/test/integration/com/redhat/theses/FilterServiceIntegrationSpec.groovy
+++ b/test/integration/com/redhat/theses/FilterServiceIntegrationSpec.groovy
@@ -1,0 +1,32 @@
+package com.redhat.theses
+
+import com.redhat.theses.Topic
+import com.redhat.theses.auth.User
+import grails.plugin.spock.IntegrationSpec
+import spock.lang.Shared
+import spock.lang.Unroll
+
+class FilterServiceIntegrationSpec extends IntegrationSpec {
+    @Shared filterService = new FilterService()
+
+    def setupSpec() {
+    }
+
+    def cleanup() {
+    }
+
+    @Unroll("Can filter #domain entries, with filter #parameters, should return #size entries")
+    void "testing filter"() {
+        expect:
+            filterService.filter(parameters, domain)?.size() == size
+            filterService.count(parameters, domain) == count
+        where:
+            parameters | domain | size | count
+            [filter: ['title-lead-description': "think"], type:  ['title-lead-description': "ilike"]] | Topic | 2 | 2
+            [filter: ['title-lead-description': "think"], type:  ['title-lead-description': "ilike"], offset: 1]  | Topic | 1 | 2
+            [filter: ['title': "think"], type:  [title: "ilike"]] | Topic | 0 | 0
+            [filter: ['email': "example"], type:  [email: "ilike"]] | User | 7 | 7
+            [filter: ['email': "example", fullName: "example"], type:  [email: "ilike", fullName: "ilike"], max: 1] | User | 1 | 3
+            [filter: ['email': "example", fullName: "example"], type:  [email: "ilike"]] | User | 0 | 0
+    }
+}


### PR DESCRIPTION
# Overview
* Filter Service now supports 'property1-property2' structure, which translates to search in property1 or property2.
* Filter in Topics, now searches in title/description/lead paragraph.
* Moved Filter in Topics above categories.
* Moved all params.type hidden fields in forms to _list()_ methods in their controller, so now filter urls are shorter.
  * old: **list?filtering=true&filter.title=test&type.title=ilike&type.owner.fullName=ilike&type.supervisions.supervisor.fullName=ilike&filter.onlyEnabled=on**
  * new: **list?filtering=true&filter.title-description-lead=typeahead&filter.onlyEnabled=on**
* Added FilterServiceIntegrationSpec for testing Filter.

# Changes in files
**ThesisController.groovy, TopicController.groovy, UserController.groovy**
* Added params.type declaration.

**FilterService.groovy**
* Added support for 'parameter1-parameter2' structure.

**topic/_topicList.gsp**
* Moved Filter section above categories.

**FilterServiceIntegrationSpec**
* Testing expected number of results of filter.