### PR TITLE
#100 - Transform info tooltips into static text in create topic forms

### DIFF
--- a/grails-app/views/application/_form.gsp
+++ b/grails-app/views/application/_form.gsp
@@ -5,16 +5,12 @@
                value="${applicationInstance.topic.id}" />
 <div class="control-group ${hasErrors(bean: applicationInstance, field: 'university', 'error')} required">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.application.create.university')}"></i>
-        </div>
         <label class="control-label" for="application.university.id">
             <strong><g:message code="university.label"/></strong>
             <strong><span class="required-indicator">*</span></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:select id="application.university.id"
                 name="application.university.id"
                 from="${universities}"
@@ -23,25 +19,27 @@
                 value="${applicationInstance?.university?.id}"
                 class="many-to-one"/>
     </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.application.create.university')}"/></p>
+    </div>
 </div>
 
 <div class="control-group ${hasErrors(bean: applicationInstance, field: 'type', 'error')} required">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.application.create.type')}"></i>
-        </div>
         <label class="control-label" for="application.type">
             <strong><g:message code="application.type.label"/></strong>
             <strong><span class="required-indicator">*</span></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:select name="application.type"
                   from="${Type.values()}"
                   noSelection="['':message(code: 'no.selection.label')]"
                   optionValue="${{g.message(code:"application.type.${it?.toString()?.toLowerCase()}.label")}}"
                   value="${applicationInstance?.type?.toString()}"/>
+    </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.application.create.type')}"/></p>
     </div>
 </div>
 

--- a/grails-app/views/category/_form.gsp
+++ b/grails-app/views/category/_form.gsp
@@ -1,17 +1,16 @@
 <%@ page import="com.redhat.theses.Category" %>
 <div class="control-group ${hasErrors(bean: categoryInstance, field: 'title', 'error')} ">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.category.create.title')}"></i>
-        </div>
         <label class="control-label" for="category.title">
             <strong><g:message code="category.title.label" /></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:textField name="category.title" value="${categoryInstance?.title}"
                      placeholder="${message(code: 'category.title.label')}" />
+    </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.category.create.title')}"/></p>
     </div>
 </div>
 

--- a/grails-app/views/thesis/_form.gsp
+++ b/grails-app/views/thesis/_form.gsp
@@ -1,32 +1,27 @@
 <sec:ifAnyGranted roles="ROLE_OWNER, ROLE_ADMIN, ROLE_SUPERVISOR">
     <div class="control-group ${hasErrors(bean: thesisInstance, field: 'title', 'error')} required">
         <div class="control-with-msg">
-            <div class="small-msg pull-right">
-                <i class="icon-info-sign"
-                   title="${message(code:'info.thesis.create.title')}"></i>
-            </div>
             <label class="control-label" for="thesis.title">
                 <strong><g:message code="thesis.title.label"/></strong>
                 <strong><span class="required-indicator">*</span></strong>
             </label>
         </div>
-        <div class="controls">
+        <div class="controls half">
             <g:textField name="thesis.title" value="${thesisInstance?.title}" placeholder="${message(code: 'thesis.title.label')}" />
+        </div>
+        <div class="info">
+            <g:message code="${message(code:'info.thesis.create.title')}"/>
         </div>
     </div>
 
     <div class="control-group ${hasErrors(bean: thesisInstance?.assignee, field: 'fullName', 'error')} required">
         <div class="control-with-msg">
-            <div class="small-msg pull-right">
-                <i class="icon-info-sign"
-                   title="${message(code:'info.thesis.create.asignee')}"></i>
-            </div>
             <label class="control-label" for="thesis.assignee.fullName">
                 <strong><g:message code="thesis.assignee.label"/></strong>
                 <strong><span class="required-indicator">*</span></strong>
             </label>
         </div>
-        <div class="controls">
+        <div class="controls half">
             <g:hiddenField name="thesis.assignee.id" value="${thesisInstance?.assignee?.id}"/>
             <a4g:textField name="thesis.assignee.fullName"
                            value="${thesisInstance?.assignee?.fullName}"
@@ -35,39 +30,37 @@
                            data-autocomplete-target="thesis.assignee.id"
                            placeholder="${message(code: 'thesis.assignee.label')}"/>
         </div>
+        <div class="info">
+            <g:message code="${message(code:'info.thesis.create.asignee')}"/>
+        </div>        
     </div>
 
     <div class="control-group ${hasErrors(bean: thesisInstance, field: 'university', 'error')} required">
         <div class="control-with-msg">
-            <div class="small-msg pull-right">
-                <i class="icon-info-sign"
-                   title="${message(code:'info.thesis.create.university')}"></i>
-            </div>
             <label class="control-label" for="thesis.university.id">
                 <strong><g:message code="university.label"/></strong>
                 <strong><span class="required-indicator">*</span></strong>
             </label>
         </div>
-        <div class="controls">
+        <div class="controls half">
             <g:select name="thesis.university.id"
                       from="${universityList}"
                       noSelection="['':message(code: 'no.selection.label')]"
                       optionKey="id"
                       value="${thesisInstance?.university?.id}"/>
         </div>
+        <div class="info">
+            <g:message code="${message(code:'info.thesis.create.university')}"/>
+        </div>
     </div>
 
     <div class="control-group ${hasErrors(bean: thesisInstance, field: 'supervisor', 'error')}">
         <div class="control-with-msg">
-            <div class="small-msg pull-right">
-                <i class="icon-info-sign"
-                   title="${message(code:'info.thesis.create.supervisor')}"></i>
-            </div>
             <label class="control-label" for="thesis.supervisor.fullName">
                 <strong><g:message code="role.supervisor.label"/></strong>
             </label>
         </div>
-        <div class="controls">
+        <div class="controls half">
             <g:hiddenField name="thesis.supervisor.id"
                            value="${thesisInstance?.supervisor?.id}"/>
             <g:hiddenField name="a4g-role[${i}]" value="${com.redhat.theses.auth.Role.SUPERVISOR}"/>
@@ -78,25 +71,27 @@
                            data-autocomplete-opts="a4g-role[${i}]@role"
                            placeholder="${message(code: 'role.supervisor.label')}"/>
         </div>
+        <div class="info">
+            <g:message code="${message(code:'info.thesis.create.supervisor')}"/>
+        </div>
     </div>
 
     <div class="control-group ${hasErrors(bean: thesisInstance, field: 'type', 'error')} required">
         <div class="control-with-msg">
-            <div class="small-msg pull-right">
-                <i class="icon-info-sign"
-                   title="${message(code:'info.thesis.create.type')}"></i>
-            </div>
             <label class="control-label" for="thesis.type">
                 <strong><g:message code="thesis.type.label"/></strong>
                 <strong><span class="required-indicator">*</span></strong>
             </label>
         </div>
-        <div class="controls">
+        <div class="controls half">
             <g:select name="thesis.type"
                       from="${typeList}"
                       noSelection="['':message(code: 'no.selection.label')]"
                       optionValue="${{g.message(code:"thesis.type.${it?.toString()?.toLowerCase()}.label")}}"
                       value="${thesisInstance?.type?.toString()}"/>
+        </div>
+        <div class="info">
+            <p><g:message code="${message(code:'info.thesis.create.type')}"/></p>
         </div>
     </div>
 
@@ -104,10 +99,6 @@
     <g:if test="${thesisInstance?.id}">
         <div class="control-group ${hasErrors(bean: thesisInstance, field: 'status', 'error')}">
             <div class="control-with-msg">
-                <span class="small-msg pull-right">
-                    <i class="icon-info-sign"
-                       title="${message(code:'info.thesis.create.status')}"></i>
-                </span>
                 <label class="control-label" for="thesis.status">
                     <strong><g:message code="thesis.status.label"/></strong>
                 </label>
@@ -119,14 +110,13 @@
                           optionValue="${{g.message(code:"thesis.status.${it?.toString()?.toLowerCase()}.label")}}"
                           value="${thesisInstance?.status?.toString()}"/>
             </div>
+            <div class="info">
+                <p><g:message code="${message(code:'info.thesis.create.status')}"/></p>
+            </div>
         </div>
 
         <div class="control-group ${hasErrors(bean: thesisInstance, field: 'grade', 'error')}">
             <div class="control-with-msg">
-                <div class="small-msg pull-right">
-                    <i class="icon-info-sign"
-                       title="${message(code:'info.thesis.create.grade')}"></i>
-                </div>
                 <label class="control-label" for="thesis.grade">
                     <strong><g:message code="thesis.grade.label"/></strong>
                 </label>
@@ -136,6 +126,9 @@
                           from="${gradeList}"
                           noSelection="['':message(code: 'no.selection.label')]"
                           value="${thesisInstance?.grade?.toString()}"/>
+            </div>
+            <div class="info">
+                <p><g:message code="${message(code:'info.thesis.create.grade')}"/></p>
             </div>
         </div>
     </g:if>

--- a/grails-app/views/thesis/create.gsp
+++ b/grails-app/views/thesis/create.gsp
@@ -17,16 +17,12 @@
     <g:form class="form-inline" action="save" id="${params.id}">
         <div class="control-group ${hasErrors(bean: thesisInstance?.topic, field: 'title', 'error')} required">
             <div class="control-with-msg">
-                <div class="small-msg pull-right"
-                      title="${message(code:'info.topic.create.topic')}">
-                    <i class="icon-info-sign"></i>
-                </div>
                 <label class="control-label" for="thesis.topic.title">
                     <strong><g:message code="topic.label" /></strong>
                     <span class="required-indicator">*</span></strong>
                 </label>
             </div>
-            <div class="controls">
+            <div class="controls half">
                 <g:hiddenField name="thesis.topic.id" value="${thesisInstance?.topic?.id}" />
                 <a4g:textField name="thesis.topic.title"
                                value="${thesisInstance?.topic?.title}"
@@ -34,6 +30,9 @@
                                placeholder="${message(code: 'topic.label')}"
                                data-autocomplete-url="${createLink(controller: 'json', action: 'listTopicsByTitle')}"
                                data-autocomplete-target="thesis.topic.id" />
+            </div>
+            <div class="info">
+                <g:message code="${message(code:'info.thesis.create.topic')}"/>
             </div>
         </div>
 

--- a/grails-app/views/topic/_form.gsp
+++ b/grails-app/views/topic/_form.gsp
@@ -1,62 +1,58 @@
 <div class="control-group ${hasErrors(bean: topicInstance, field: 'title', 'error')} required">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign" title="${message(code:'info.topic.create.title')}"></i>
-        </div>
         <label class="control-label" for="topic.title">
             <strong><g:message code="topic.title.label"/></strong>
             <span class="required-indicator">*</span>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:textField name="topic.title" value="${topicInstance?.title}"
                      placeholder="${message(code:'topic.title.label')}" />
+    </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.topic.create.title')}"/></p>
     </div>
 </div>
 
 <div class="control-group ${hasErrors(bean: topicInstance, field: 'enabled', 'error')}">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign" title="${message(code:'info.topic.create.state')}"></i>
-        </div>
         <label class="control-label">
             <strong><g:message code="topic.state.label"/></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <label class="checkbox" for="topic.enabled" id="thesis-enabled">
             <g:checkBox name="topic.enabled" value="${topicInstance?.enabled}" />
             <g:message code="topic.enabled.label"/>
         </label>
     </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.topic.create.state')}"/></p>
+    </div>
 </div>
 
 <div class="control-group ${hasErrors(bean: topicInstance, field: 'secondaryTitle', 'error')}">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.topic.create.secondaryTitle')}"></i>
-        </div>
         <label class="control-label" for="topic.secondaryTitle">
             <strong><g:message code="topic.secondaryTitle.label"/></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:textField name="topic.secondaryTitle" value="${topicInstance?.secondaryTitle}" placeholder="${message(code:'topic.secondaryTitle.label')}" />
+    </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.topic.create.secondaryTitle')}"/></p>
     </div>
 </div>
 
 <div class="control-group ${hasErrors(bean: topicInstance, field: 'owner', 'error')} required">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign" title="${message(code:'info.topic.create.owner')}"></i>
-        </div>
         <label class="control-label" for="topic.owner.fullName">
             <strong><g:message code="role.owner.label"/></strong>
             <span class="required-indicator">*</span>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:hiddenField name="topic.owner.id" value="${topicInstance?.owner?.id}"/>
         <g:hiddenField name="a4g-role" value="${com.redhat.theses.auth.Role.OWNER}"/>
         <a4g:textField name="topic.owner.fullName" value="${topicInstance?.owner?.fullName}"
@@ -65,39 +61,57 @@
                        data-autocomplete-opts="a4g-role@role"
                        placeholder="${message(code:'role.owner.label')}" />
     </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.topic.create.owner')}"/></p>
+    </div>
 </div>
 
 <div class="control-group ${hasErrors(bean: topicInstance, field: 'universities', 'error')}">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.topic.create.universities')}"></i>
-        </div>
         <label class="control-label">
             <strong><g:message code="topic.universities.label"/></strong>
         </label>
     </div>
-    <div class="controls">
-        <richg:multiselect name="topic.universities" from="${universities}"
-                           optionKey="id" value="${topicInstance?.universities*.id}" />
-    </div>
+    <table>
+        <tr>
+            <td>
+                <div class="controls half">
+                    <richg:multiselect name="topic.universities" from="${universities}"
+                                       optionKey="id" value="${topicInstance?.universities*.id}" />
+                </div>
+            </td>
+            <td>     
+                <div class="info">
+                    <p><g:message code="${message(code:'info.topic.create.universities')}"/></p>
+                </div>
+            </td>    
+        </tr>    
+    </table>
 </div>
 
 
 
 <div class="control-group ${hasErrors(bean: topicInstance, field: 'types', 'error')}">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign" title="${message(code:'info.topic.create.types')}"></i>
-        </div>
         <label class="control-label">
             <strong><g:message code="topic.types.label"/></strong>
         </label>
     </div>
-    <div class="controls">
-        <richg:multiselect name="topic.types" from="${types}" value="${topicInstance?.types}"
-                           optionValue="${{g.message(code:"topic.type.${it?.toString()?.toLowerCase()}.label")}}"/>
-    </div>
+    <table>
+        <tr>
+            <td>
+                <div class="controls half">
+                    <richg:multiselect name="topic.types" from="${types}" value="${topicInstance?.types}"
+                                       optionValue="${{g.message(code:"topic.type.${it?.toString()?.toLowerCase()}.label")}}"/>
+                </div>
+             </td>
+             <td>   
+                <div class="info">
+                    <p><g:message code="${message(code:'info.topic.create.types')}"/></p>
+                </div>
+             </td>
+         </tr>
+    </table>   
 </div>
 
 <div class="control-group">
@@ -159,18 +173,25 @@
 
 <div class="control-group ${hasErrors(bean: topicInstance, field: 'categories', 'error')}">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.topic.create.categories')}"></i>
-        </div>
         <label class="control-label" for="topic.categories">
             <strong><g:message code="topic.categories.label"/></strong>
         </label>
     </div>
-    <div class="controls">
-        <richg:multiselect name="topic.categories" from="${com.redhat.theses.Category.list()}"
-                  optionKey="id" value="${topicInstance?.categories*.id}"/>
-    </div>
+    <table>
+        <tr>
+            <td>
+                <div class="controls half">
+                    <richg:multiselect name="topic.categories" from="${com.redhat.theses.Category.list()}"
+                              optionKey="id" value="${topicInstance?.categories*.id}"/>
+                </div>
+             </td>
+             <td>       
+                <div class="info">
+                    <p><g:message code="${message(code:'info.topic.create.categories')}"/></p>
+                </div>
+             </td>
+         </tr>
+     </table>   
 </div>
 
 <div class="control-group">

--- a/grails-app/views/university/_form.gsp
+++ b/grails-app/views/university/_form.gsp
@@ -1,30 +1,28 @@
 <div class="control-group ${hasErrors(bean: universityInstance, field: 'name', 'error')} required">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.university.create.name')}"></i>
-        </div>
         <label class="control-label" for="university.name">
             <strong><g:message code="university.name.label"/></strong>
             <span class="required-indicator">*</span></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:textField name="university.name" value="${universityInstance?.name}" placeholder="${message(code: 'university.name.label')}"/>
+    </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.university.create.name')}"/></p>
     </div>
 </div>
 <div class="control-group ${hasErrors(bean: universityInstance, field: 'acronym', 'error')} required">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.university.create.acronym')}"></i>
-        </div>
         <label class="control-label" for="university.acronym">
             <strong><g:message code="university.acronym.label"/></strong>
             <span class="required-indicator">*</span></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:textField name="university.acronym" value="${universityInstance?.acronym}" placeholder="${message(code: 'university.acronym.label')}"/>
+    </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.university.create.acronym')}"/></p>
     </div>
 </div>

--- a/grails-app/views/user/_form.gsp
+++ b/grails-app/views/user/_form.gsp
@@ -1,35 +1,33 @@
 <%@ page import="com.redhat.theses.auth.Role" %>
 <div class="control-group ${hasErrors(bean: userInstance, field: 'email', 'error')} required">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.user.create.email')}"></i>
-        </div>
         <label class="control-label" for="user.email">
             <strong><g:message code="user.email.label"/>
             <span class="required-indicator">*</span></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:textField name="user.email" value="${userInstance?.email}"
                      placeholder="${message(code: 'user.email.label')}" />
+    </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.user.create.email')}"/></p>
     </div>
 </div>
 
 <div class="control-group ${hasErrors(bean: userInstance, field: 'fullName', 'error')} required">
     <div class="control-with-msg">
-        <div class="small-msg pull-right">
-            <i class="icon-info-sign"
-               title="${message(code:'info.user.create.fullName')}"></i>
-        </div>
         <label class="control-label" for="user.fullName">
             <strong><g:message code="user.fullName.label"/>
             <span class="required-indicator">*</span></strong>
         </label>
     </div>
-    <div class="controls">
+    <div class="controls half">
         <g:textField name="user.fullName" value="${userInstance?.fullName}"
                      placeholder="${message(code: 'user.fullName.label')}" />
+    </div>
+    <div class="info">
+        <p><g:message code="${message(code:'info.user.create.fullName')}"/></p>
     </div>
 </div>
 
@@ -44,10 +42,21 @@
                 <span class="required-indicator">*</span></strong>
         </label>
     </div>
-    <div class="controls">
-        <richg:multiselect name="user.roles" from="${Role.values()}" value="${userInstance?.roles}" size="4"
-                           optionValue="${{g.message(code:"role.${it?.toString()?.toLowerCase()}.label")}}"/>
-    </div>
+    <table>
+        <tr>
+            <td>    
+               <div class="controls half">
+                   <richg:multiselect name="user.roles" from="${Role.values()}" value="${userInstance?.roles}" size="4"
+                                      optionValue="${{g.message(code:"role.${it?.toString()?.toLowerCase()}.label")}}"/>
+               </div>
+            </td>
+            <td>   
+               <div class="info">
+                   <p><g:message code="${message(code:'info.user.create.roles')}"/></p>
+               </div>
+            </td>
+        </tr>
+    </table>  
 </div>
 
 <div class="control-group ${hasErrors(bean: userInstance, field: 'enabled', 'error')} ">

--- a/web-app/less/main.less
+++ b/web-app/less/main.less
@@ -533,6 +533,20 @@ ul form {
   margin: 0;
 }
 
+.info {
+  font-size: @fontSizeSmall;
+  height: @inputHeight;
+  line-height: @inputHeight;
+  max-width: 690-350px; 
+  padding: 4px 8px;
+  display: inline-block;
+  & p {
+      display: inline-block;
+      vertical-align: middle;
+      line-height: normal;
+  }
+}
+
 .control-group {
   margin-bottom: 20px;
 
@@ -547,7 +561,10 @@ ul form {
       .box-shadow(none);
     }
   }
-
+  .half {
+    width: 302px;
+    display: inline-block;
+  }
   #thesis-enabled {
     padding: 0px 0px 5px;
   }
@@ -1369,7 +1386,6 @@ table#tags {
       padding-right: 10px;
     }
   }
-
   &.faq-locale {
     float: right;
 


### PR DESCRIPTION
# Overview
* Most of the info tooltips were transformed into static text to fill up the empty space.
 * Added class _half_ to most of the fields to restrict their width.
* In case of multiselect fields I had to wrap them in table because otherwise tooltip text was trailing in weird positions.