### PR TITLE
#134 - Plaintext password in registration email

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -503,7 +503,8 @@ footer.faq.label=FAQ
 # MAIL
 mail.subscription.subject=[Red Hat] Notification: {0}
 
-mail.registration.confirmation=Your login details:\n\nYour name: {0}\nYour password*: {1}\n\nPlease confirm your registration by clicking on the following link:\n{2}\n\n\n------\n* Please delete this email after you have confirmed for security purposes.
+mail.registration.confirmation=Your login details:\n\nYour name: {0}\n\nPlease confirm your registration by clicking on the following link:\n{1}.
+mail.registration.by.admin.confirmation=Your login details:\n\nYour name: {0}\nYour password*: {1}\n\nThis password is only temporary, please change it immediately\n\nPlease confirm your registration by clicking on the following link:\n{2}\n------\n* Please delete this email after you have confirmed for security purposes.
 mail.registration.confirmation.subject=[Red Hat theses] Please confirm your registration
 mail.registration.by.admin.confirmation.subject=[Red Hat theses] Please confirm your account
 

--- a/grails-app/i18n/messages_cs.properties
+++ b/grails-app/i18n/messages_cs.properties
@@ -501,9 +501,10 @@ footer.faq.label=FAQ
 # MAIL
 mail.subscription.subject=[Red Hat theses] Notifikace: {0}
 
-mail.registration.confirmation=Vaše přihlašovací údaje:\n\nVaše jméno: {0}\nVaše heslo*: {1}\n\nProsím potvrďte vaši registraci kliknutím na následující odkaz:\n{2}\n\n\n------\n* Prosím smažte tento email poté co potvrdíte vaši registraci.
+mail.registration.confirmation=Vaše přihlašovací údaje:\n\nVaše jméno: {0}\n\nProsím potvrďte vaši registraci kliknutím na následující odkaz:\n{1}.
+mail.registration.by.admin.confirmation=Vaše přihlašovací údaje:\n\nVaše jméno: {0}\nVaše heslo*: {1}\n\nToto heslo je pouze dočasné, změnte si ho co nejdříve.\n\nProsím potvrďte vaši registraci kliknutím na následující odkaz:\n{2}\n------\n* Prosím smažte tento email poté co potvrdíte vaši registraci.
 mail.registration.confirmation.subject=[Red Hat theses] Prosím potvrďte vaši registraci
-mail.registration.by.admin.confirmation.subject=Prosím potvrďte vaš účet
+mail.registration.by.admin.confirmation.subject=[Red Hat theses] Prosím potvrďte vaš účet
 
 mail.email.confirmation=Změnil jste vaši emailovou adresu, vaše nová emailová adresa je:\n\n{0}\n\nProsím potvrďte vaši novou emailovou adresu kliknutím na následující odkaz:\n\n{1}
 mail.email.confirmation.subject=[Red Hat theses] Prosím potvrďte vaši emailovou adresu

--- a/grails-app/services/com/redhat/theses/listeners/UserListenerService.groovy
+++ b/grails-app/services/com/redhat/theses/listeners/UserListenerService.groovy
@@ -39,15 +39,17 @@ class UserListenerService {
 
         // send confirmation email
         def subject = messageSource.getMessage('mail.registration.confirmation.subject', [].toArray(), LCH.locale)
+        def model = [code: 'mail.registration.confirmation', args: [e.user.fullName]]
         if (e.createdByAdmin) {
             subject = messageSource.getMessage('mail.registration.by.admin.confirmation.subject', [].toArray(), LCH.locale)
+            model = [code: 'mail.registration.by.admin.confirmation', args: [e.user.fullName, e.password]]
         }
         try {
             emailConfirmationService.sendConfirmation(
                 to: e.user.email,
                 subject: subject,
                 view: '/emailConfirmation/message',
-                model: [code: 'mail.registration.confirmation', args: [e.user.fullName, e.password]],
+                model: model,
                 id: e.user.id,
                 event: "userCreated"
             )


### PR DESCRIPTION
- Password is now send only if your account was created by Administrator.
- Added warning to change your password if it was generated.
