### PR TITLE
Bug fixes (Locales problem, configuration problem)

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -79,6 +79,7 @@ grails.project.dependency.resolution = {
         compile ":lesscss-resources:1.3.1"
         compile ":hibernate-filter:0.3.2"
         compile ":feeds:1.5"
+        compile ':locale-configuration:1.1.1'
         test(":spock:0.7") {
             exclude "spock-grails-support"
         }

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -138,6 +138,10 @@ log4j = {
     }
 }
 
+// Locale settings
+grails.plugin.localeConfiguration.supportedLocales = [Locale.US, new Locale("cs")]
+grails.plugin.localeConfiguration.defaultLocale = Locale.US
+
 // Added by the Spring Security Core plugin:
 grails.plugins.springsecurity.userLookup.userDomainClassName = 'com.redhat.theses.auth.User'
 grails.plugins.springsecurity.authority.className = 'com.redhat.theses.auth.Role'

--- a/grails-app/services/com/redhat/theses/config/Configuration.groovy
+++ b/grails-app/services/com/redhat/theses/config/Configuration.groovy
@@ -44,6 +44,7 @@ class Configuration {
             config = configurationProvider.load()
             if (!config) {
                 config = createDefaultConfig()
+                configurationProvider.save(config)
             }
         }
     }
@@ -51,7 +52,6 @@ class Configuration {
     public ConfigObject createDefaultConfig() {
         Class configClass = getClass().classLoader.loadClass('DefaultRuntimeConfig')
         def config = new ConfigSlurper().parse(configClass)
-        configurationProvider.save(config)
         config
     }
 }


### PR DESCRIPTION
- Only English (en_US) a Czech (cs) locales are now allowed.
  - Everything else will be considered English (en_US).
  - I used Grails Locale Configuration Plugin to make it easier.
- Saving of default config is now done outside **createDefaultConfig()** function.
