### PR TITLE
#141 - Sticky footer

### DIFF
--- a/web-app/less/main.less
+++ b/web-app/less/main.less
@@ -68,12 +68,22 @@
 }
 
 /*---------MAIN---------*/
+html {
+  height: 100%;   
+}
+
+.container {
+  flex: 1;    
+}
 
 body {
   overflow-y: scroll;
   background-image: url('../images/bg.png');
   background-repeat: repeat;
   min-width: 1041px;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;  
 }
 
 footer {


### PR DESCRIPTION
* Footer is now sticky, which means he either sticks to bottom of the page or the bottom of the content depending on height of content.
* I used flexbox which is [supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes#Browser_compatibility)