### PR TITLE
#149 - Unconfirmed registration older than 24h are now periodically purged

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -80,6 +80,7 @@ grails.project.dependency.resolution = {
         compile ":hibernate-filter:0.3.2"
         compile ":feeds:1.5"
         compile ':locale-configuration:1.1.1'
+        compile ':quartz:1.0-RC2'
         test(":spock:0.7") {
             exclude "spock-grails-support"
         }

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -108,6 +108,7 @@ log4j = {
                   'grails.app.services.com.redhat',
                   'grails.app.taglib.com.redhat',
                   'grails.app.conf.com.redhat',
+                  'grails.app.jobs.com.redhat',
                   'grails.app.filters.com.redhat'
         }
 

--- a/grails-app/conf/TestBootStrap.groovy
+++ b/grails-app/conf/TestBootStrap.groovy
@@ -1,3 +1,5 @@
+import org.apache.el.parser.AstMinus
+
 import com.gmongo.GMongo
 import com.redhat.theses.*
 import com.redhat.theses.auth.Role
@@ -91,6 +93,41 @@ class TestBootStrap {
                              Role.OWNER,
                              Role.SUPERVISOR,
                              Role.STUDENT]
+                ).save(flush: true)
+                
+                //UNCONFIRMED USERS
+                def notConfirm1 = new User(
+                    email: 'n1@example.com',
+                    fullName: 'Student One',
+                    password: "owner2",
+                    enabled: false,
+                    roles: [
+                         Role.STUDENT]
+                ).save(flush: true)
+                notConfirm1.dateCreated = new Date().minus(2)
+                notConfirm1.save(flush: true)
+                
+                def notConfirm2 = new User(
+                    email: 'n2@example.com',
+                    fullName: 'Student Two',
+                    password: "owner2",
+                    enabled: false,
+                    dateCreated: new Date().previous(),
+                    roles: [
+                         Role.SUPERVISOR,
+                         Role.STUDENT]
+                ).save(flush: true)
+                notConfirm2.dateCreated = new Date().minus(1)
+                notConfirm2.save(flush: true)
+
+                def notConfirm3 = new User(
+                    email: 'n3@example.com',
+                    fullName: 'Student Three',
+                    password: "owner2",
+                    enabled: false,
+                    roles: [
+                         Role.OWNER,
+                         Role.STUDENT]
                 ).save(flush: true)
                 //TAGS
                 def grailsTag = new Tag(title: 'grails').save(flush: true)

--- a/grails-app/jobs/com/redhat/theses/RegistrationPurgeJob.groovy
+++ b/grails-app/jobs/com/redhat/theses/RegistrationPurgeJob.groovy
@@ -1,0 +1,23 @@
+package com.redhat.theses
+
+import com.redhat.theses.auth.User;
+import com.redhat.theses.auth.UserService
+import org.apache.commons.logging.LogFactory;
+import groovy.util.logging.Log4j;
+import org.apache.log4j.Logger;
+
+class RegistrationPurgeJob {
+    // Couldn't use DI because it doesn't work when testing
+    def userService = new UserService()
+
+    static triggers = {
+        cron name: 'cronTrigger', cronExpression: '0 0 * 1/1 * ? *'
+    }
+
+    def execute() {
+        User.findAllNotEnabledByDateCreatedLessThan(new Date().previous()).each {
+            log.info "Removing " + it.email + "'s registration, because it is older than 24h and still unconfirmed."
+            userService.delete(it);
+        }
+    }
+}

--- a/test/integration/com/redhat/theses/FilterServiceIntegrationSpec.groovy
+++ b/test/integration/com/redhat/theses/FilterServiceIntegrationSpec.groovy
@@ -25,7 +25,7 @@ class FilterServiceIntegrationSpec extends IntegrationSpec {
             [filter: ['title-lead-description': "think"], type:  ['title-lead-description': "ilike"]] | Topic | 2 | 2
             [filter: ['title-lead-description': "think"], type:  ['title-lead-description': "ilike"], offset: 1]  | Topic | 1 | 2
             [filter: ['title': "think"], type:  [title: "ilike"]] | Topic | 0 | 0
-            [filter: ['email': "example"], type:  [email: "ilike"]] | User | 7 | 7
+            [filter: ['email': "example"], type:  [email: "ilike"]] | User | 10 | 10
             [filter: ['email': "example", fullName: "example"], type:  [email: "ilike", fullName: "ilike"], max: 1] | User | 1 | 3
             [filter: ['email': "example", fullName: "example"], type:  [email: "ilike"]] | User | 0 | 0
     }

--- a/test/integration/com/redhat/theses/RegistrationPurgeJobIntegrationSpec.groovy
+++ b/test/integration/com/redhat/theses/RegistrationPurgeJobIntegrationSpec.groovy
@@ -1,0 +1,24 @@
+package com.redhat.theses
+
+import com.redhat.theses.RegistrationPurgeJob
+import com.redhat.theses.auth.User
+
+import grails.plugin.spock.IntegrationSpec
+import spock.lang.Shared
+import spock.lang.Unroll
+
+class RegistrationPurgeJobIntegrationSpec extends IntegrationSpec {
+    @Shared job = new RegistrationPurgeJob()
+
+    void "All unconfirmed registration older than 24h will be deleted"() {
+        given:
+            def originalCount = User.count()
+        when: "Executing job"
+            job.execute()
+            def newCount = User.count()
+        then: "There should be less Users now (exactly 9)"
+            originalCount != newCount 
+            newCount == 9
+    }
+
+}


### PR DESCRIPTION
# Overview
- Added Quartz job which will every day at midnight remove all unconfirmed registrations older than 24h.
  - Added Quartz as dependency, used same version as sendMail plugin.
- Added test to make sure that it removes only registration older than 24h.

# Changes in files
**BuildConfig.groovy**
- Added Quartz as a dependency.

**Config.groovy**
- Added jobs directory to log4j config to allow to write into log.

**TestBootStrap.groovy**
- Added 3 not enabled Users with different dateCreated.
  - Had to create User, save it, change dateCreated and save it again, because otherwise grails would override my date.

**RegistrationPurgeJob.groovy**
- Quartz job responsible for purging registration.
- Cron expression itself is untested and unchecked, because I can't test 24h delays, tested it on 10sec delays though.

**FilterServiceIntegrationSpec.groovy**
- Updated tests to reflect changes in testing configuration.

**RegistrationPurgeJobIntegrationSpec.groovy**
- Integration test responsible for making sure that purge job deletes only the right registrations.