### PR TITLE
#149 - Admin can now manually confirm registrations

### DIFF
--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -103,7 +103,13 @@ class BootStrap {
                         enabled: true,
                         roles: [Role.OWNER, Role.SUPERVISOR, Role.STUDENT]
                 ).save(flush: true)
-
+                def unconfirmed = new User(
+                    email: 'student1@example.com',
+                    fullName: 'Student One',
+                    password: "student1",
+                    enabled: false,
+                    roles: [Role.STUDENT]
+                ).save(flush: true)
                 // TAGS
                 def javaTag = new Tag(title: 'java').save(flush: true)
                 def groovyTag = new Tag(title: 'groovy').save(flush: true)

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -216,6 +216,9 @@ user.no.users.found=No users were found
 user.no.theses.found=The user does not have any theses.
 user.no.activity.found=The user doesn't have any events to show.
 user.not.found=User not found with id {0}
+user.not.confirmed= Registration of user {0} could not be confirmed
+user.confirmed=Registration of user {0} has been successfully confirmed
+user.already.confirmed=Registration of user {0} is already confirmed
 user.created=User {0} has been successfully created
 user.deleted=User {0} has been successfully deleted
 user.updated=User {0} has been successfully updated
@@ -478,6 +481,8 @@ feed.application.created=User <a href="{1}">{0}</a> created <a href="{2}">new ap
 feed.application.approved=User <a href="{1}">{0}</a> approved <a href="{2}">your application</a> for topic <a href="{4}">{3}</a>.
 feed.application.declined=User <a href="{1}">{0}</a> declined <a href="{2}">your application</a> for topic <a href="{4}">{3}</a>.
 
+feed.registration.confirmed=Your registration was confirmed by administrator <a href="{1}">{0}</a>.
+
 # FAQ
 faq.label=FAQ
 faq.list.title=Frequently asked questions
@@ -711,6 +716,7 @@ registration.confirmed.message=You have successfully confirmed your account. You
 profile.edit.title=Edit Profile
 profile.edit.header=Edit Profile
 profile.edit.button=Edit Profile
+profile.confirm.button=Confirm registration
 
 profile.not.authenticated=You must be logged in to view your profile
 profile.updated=Your profile has been successfully updated

--- a/grails-app/i18n/messages_cs.properties
+++ b/grails-app/i18n/messages_cs.properties
@@ -215,6 +215,9 @@ user.no.users.found=Žádní uživatelé nebyli nalezeni
 user.no.theses.found=Tento uživatel nemá žádné kvalifikační prace
 user.no.activity.found=Tento uživatel nemá žádnou aktivitu
 user.not.found=Uživatel s id {0} nenalezen
+user.not.confirmed=Nepodařilo se potrvdit registraci uživatele {0}
+user.confirmed=Registrace uživatele {0} byla úspěšně potrvzena
+user.already.confirmed=Registrace uživatele {0} už je potvrzena
 user.created=Uživatel {0} byl úspěšně vytvořen
 user.deleted=Uživatel {0} byl úspěšně smazán
 user.updated=Uživatel {0} byl úspěšně uložen
@@ -476,6 +479,8 @@ feed.comment.created=Uživatel <a href="{1}">{0}</a> okomentoval <a href="{3}">{
 feed.application.created=Uživatel <a href="{1}">{0}</a> vytvořil <a href="{2}">novou přihlášku</a> pro téma <a href="{4}">{3}</a>.
 feed.application.approved=Uživatel <a href="{1}">{0}</a> schválil <a href="{2}">vaši prihlášku</a> pro téma <a href="{4}">{3}</a>.
 
+feed.registration.confirmed=Vaše registrace byla potrvzena administrátorem <a href="{1}">{0}</a>.
+
 # FAQ
 faq.label=FAQ
 faq.list.title=Často kladené otázky
@@ -709,6 +714,7 @@ registration.confirmed.message=Úspěšně jste potvrdil vaši registraci. Za mo
 profile.edit.title=Upravení profilu
 profile.edit.header=Upravení profilu
 profile.edit.button=Upravit profil
+profile.confirm.button=Potvrdit registraci
 
 profile.not.authenticated=Pro zobrazení vašeho profilu musíte být přihlášený
 profile.updated=Váš profil byl úspěšně uložen

--- a/grails-app/views/layouts/user/showLayout.gsp
+++ b/grails-app/views/layouts/user/showLayout.gsp
@@ -106,6 +106,14 @@
         </sec:ifLoggedIn>
         <div class="controls pull-right">
             <sec:ifAnyGranted roles="ROLE_ADMIN">
+               <g:if test="${!userInstance?.enabled}" >
+                    <g:link class="tms-btn" controller="user" action="confirm" id="${userInstance?.id}">
+                        <i class="icon-check-sign"></i> <g:message code="profile.confirm.button" />
+                    </g:link>
+               </g:if>
+            </sec:ifAnyGranted>
+            
+            <sec:ifAnyGranted roles="ROLE_ADMIN">
             <g:link class="tms-btn" controller="user" action="edit" id="${userInstance?.id}">
                 <i class="icon-wrench"></i> <g:message code="default.edit.button" />
             </g:link>

--- a/src/groovy/com/redhat/theses/events/UserConfirmedEvent.groovy
+++ b/src/groovy/com/redhat/theses/events/UserConfirmedEvent.groovy
@@ -1,0 +1,16 @@
+package com.redhat.theses.events
+
+import com.redhat.theses.auth.User
+
+/**
+ * @author vdedik@redhat.com
+ */
+class UserConfirmedEvent {
+    User user
+    User admin
+
+    UserConfirmedEvent(User user, User admin) {
+        this.user = user
+        this.admin = admin
+    }
+}

--- a/web-app/less/main.less
+++ b/web-app/less/main.less
@@ -943,6 +943,8 @@ h3#file-upload {
   padding: 5px 10px;
   line-height: normal;
   *border: 0;
+  margin-left: 5px;
+
   .border-radius(@baseBorderRadius);
   .ie7-restore-left-whitespace();
   .box-shadow(0px 1px 1px @grayTitles);


### PR DESCRIPTION
# Overview
- Admin can now manually confirm registrations.
  - Button can be found in user's profile.
  - User will be notified by email.

# Changes in files
**BootStrap.groovy**
- Added one unconfirmed student into testing configuration.

**UserController.groovy**
- Added confirm method which confirms user if he isn't already.

**UserListenerService.groovy**
- Added DI of SubscriptionService and GrailsLinkGenerator.
- Added event for admin confirmation.

**layouts/user/showLayout.gsp**
- Added button for manually confirming users.

**main.less**
- Added small margin between buttons to make it look better.